### PR TITLE
Removed inconsiderate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-﻿# Zyphe
+﻿# _
 
-Zyphe is my programming language that I'm making to
+_ is my programming language that I'm making to
 run on the [Rainbow runtime](https://github.com/luminous-foundation/Rainbow).
 The purpose of this language is to encourage thought into how memory is used. I designed
 the language so that people would distinguish between heap and stack memory purposefully.


### PR DESCRIPTION
This PR replaces the rather inconsiderate naming of this programming language with a temporary placeholder, until a substitute can be found that does not appropriate from the Mizo people, who speak the Zyphe language.